### PR TITLE
Fixed two issues

### DIFF
--- a/includes/helper.php
+++ b/includes/helper.php
@@ -352,15 +352,17 @@ function generate_access_token() {
 	wp_die();
 }
 
-function write_log( $data ) {
-	if ( empty( $data ) ) {
-		return;
-	}
-	if ( true === WP_DEBUG ) {
-		if ( is_array( $data ) || is_object( $data ) ) {
-			error_log( print_r( $data, true ) );
-		} else {
-			error_log( $data );
+if(!function_exists('write_log')){
+	function write_log( $data ) {
+		if ( empty( $data ) ) {
+			return;
+		}
+		if ( true === WP_DEBUG ) {
+			if ( is_array( $data ) || is_object( $data ) ) {
+				error_log( print_r( $data, true ) );
+			} else {
+				error_log( $data );
+			}
 		}
 	}
 }

--- a/includes/wc-blink-gateway-class.php
+++ b/includes/wc-blink-gateway-class.php
@@ -785,9 +785,9 @@ class WC_Blink_Gateway extends WC_Payment_Gateway {
 		wp_register_style( 'woocommerce_blink_payment_style', plugins_url( '../assets/css/style.css', __FILE__ ), array(), $this->version );
 		// and this is our custom JS in your plugin directory that works with token.js
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
-			wp_register_script( 'woocommerce_blink_payment', plugins_url( '../assets/js/order-pay.js', __FILE__ ), array( 'jquery' ), $this->version, true );      
+			wp_register_script( 'woocommerce_blink_payment_order_pay', plugins_url( '../assets/js/order-pay.js', __FILE__ ), array( 'jquery' ), $this->version, true );      
 		} else {
-			wp_register_script( 'woocommerce_blink_payment', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $this->version, true );       
+			wp_register_script( 'woocommerce_blink_payment_checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $this->version, true );       
 		}
 			// in most payment processors you have to use API KEY and SECRET KEY to obtain a token
 			wp_localize_script(
@@ -816,8 +816,11 @@ class WC_Blink_Gateway extends WC_Payment_Gateway {
 					'order_id'      		 => $order->get_id(),
 				)
 			);
+			wp_enqueu_script( 'woocommerce_blink_payment_order_pay' );
+		}else{
+			wp_enqueu_script( 'woocommerce_blink_payment_checkout' );
 		}
-		wp_enqueue_script( 'woocommerce_blink_payment' );
+
 		wp_enqueue_style( 'woocommerce_blink_payment_style' );
 		$custom_css = $this->get_option( 'custom_style' );
 		if ( $custom_css ) {

--- a/includes/wc-blink-gateway-class.php
+++ b/includes/wc-blink-gateway-class.php
@@ -791,7 +791,7 @@ class WC_Blink_Gateway extends WC_Payment_Gateway {
 		}
 			// in most payment processors you have to use API KEY and SECRET KEY to obtain a token
 			wp_localize_script(
-				'woocommerce_blink_payment',
+				'woocommerce_blink_payment_checkout',
 				'blink_params',
 				array(
 					'ajaxurl'       => admin_url( 'admin-ajax.php' ),
@@ -802,7 +802,7 @@ class WC_Blink_Gateway extends WC_Payment_Gateway {
 			$order = wc_get_order( get_query_var( 'order-pay' ) );
 
 			wp_localize_script(
-				'woocommerce_blink_payment',
+				'woocommerce_blink_payment_order_pay',
 				'order_params',
 				array(
 					'billing_first_name' => $order->get_billing_first_name(),


### PR DESCRIPTION
Fixed `write_log` which might be declared by other plugins e.g. popup-maker

Other option is renaming the function to something with a prefix `blink_write_log` maybe

**P.s. **I don't see any usage for the function write_logs anywhere in the plugin**, is it needed at all?

Also gave the javascript files unique handles to avoid caching plugins serving the wrong file - see details in commit